### PR TITLE
fix: 🐛 Fix semantic version check on react-scripts-parcel

### DIFF
--- a/packages/create-react-app-parcel/package.json
+++ b/packages/create-react-app-parcel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-react-app-parcel",
-  "version": "0.0.38",
+  "version": "0.0.39",
   "description": "💩",
   "files": [
     "index.js",

--- a/packages/react-scripts-parcel/package.json
+++ b/packages/react-scripts-parcel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-scripts-parcel",
-  "version": "0.0.38",
+  "version": "0.0.39",
   "description": "Configuration and scripts for Create React App parcel.",
   "repository": "sw-yx/create-react-app-parcel",
   "license": "MIT",
@@ -66,6 +66,7 @@
     "pkg-up": "2.0.0",
     "raf": "^3.4.0",
     "react-dev-utils": "^5.0.0",
+    "semver": "^6.3.0",
     "whatwg-fetch": "^2.0.4"
   }
 }

--- a/packages/react-scripts-parcel/scripts/utils/verifyPackageTree.js
+++ b/packages/react-scripts-parcel/scripts/utils/verifyPackageTree.js
@@ -9,6 +9,7 @@
 'use strict';
 
 const chalk = require('chalk');
+const semver = require('semver');
 const fs = require('fs');
 const path = require('path');
 
@@ -20,7 +21,7 @@ function verifyPackageTree() {
     // These are packages most likely to break in practice.
     // See https://github.com/facebook/create-react-app/issues/1795 for reasons why.
     // I have not included Babel here because plugins typically don't import Babel (so it's not affected).
-    // 'eslint',
+    'eslint',
     'jest',
     // 'webpack', // CRAP: swyx: dont need these
     // 'webpack-dev-server',
@@ -70,8 +71,9 @@ function verifyPackageTree() {
       const depPackageJson = JSON.parse(
         fs.readFileSync(maybeDepPackageJson, 'utf8')
       );
+      
       const expectedVersion = expectedVersionsByDep[dep];
-      if (depPackageJson.version !== expectedVersion) {
+      if (!semver.satisfies(depPackageJson.version, expectedVersion)) {
         console.error(
           chalk.red(
             `\nThere might be a problem with the project dependency tree.\n` +


### PR DESCRIPTION
verifyPackageTree was comparing version of dependencies without
considering semantic versioning ranges, which was causing errors running
start script.